### PR TITLE
Fix broken desktop Twitter sharing

### DIFF
--- a/src/share.js
+++ b/src/share.js
@@ -568,7 +568,7 @@ navigator.share = navigator.share || (function () {
 								break;
 							}
 							case 'twitter': {
-								window.open(`http://twitter.com/share?text=${text}&url=${url}&hashtags=${hashtags || ''}`);
+								window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}&hashtags=${hashtags || ''}`);
 								break;
 							}
 							case 'linkedin': {


### PR DESCRIPTION
Twitter now uses Web Intents urls. Updated to support.