### PR TITLE
Add hashtag option to Facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ navigator.share({
 ```
 
 But in this case, you can also pass your `Facebook App Id` to enable sharing with **messenger**.
-Also, you can pass in a list of hashtags to be used when sharing with twitter.
+Also, you can pass in a list of hashtags to be used when sharing with twitter or facebook. Only one hashtag can be shared with facebook so the first one in the list will be shared.
 
 ```js
 navigator.share({

--- a/src/share.js
+++ b/src/share.js
@@ -226,7 +226,7 @@ navigator.share = navigator.share || (function () {
 				reject('Invalid Params');
 			}
 
-			const { title, url, fbId, hashtags } = data;
+			const { title, url, fbId, hashtags, hashtag } = data;
 			const configs = {
 				...{
 					copy: true,
@@ -571,7 +571,7 @@ navigator.share = navigator.share || (function () {
 									'https://www.facebook.com/sharer/sharer.php?' +
 									'u=' + encodeURIComponent(url) +
 									'&quote=' + encodeURIComponent(text) +
-                  '&hashtag=' + (hashtags || '')
+                  '&hashtag=' + (hashtag || hashtags || '')
 								)
 								break;
 							}

--- a/src/share.js
+++ b/src/share.js
@@ -570,7 +570,8 @@ navigator.share = navigator.share || (function () {
 								window.open(
 									'https://www.facebook.com/sharer/sharer.php?' +
 									'u=' + encodeURIComponent(url) +
-									'&quote=' + encodeURIComponent(text)
+									'&quote=' + encodeURIComponent(text) +
+                  '&hashtag=' + (hashtags || '')
 								)
 								break;
 							}


### PR DESCRIPTION
Support `hashtag` for Facebook sharing

Allow to specify `hashtag` to pick the one tag that should be passed on to the Facebook share dialog. Sometimes, the developer might want to have the Twitter hashtags in a certain order and the one hashtag that should be passed on to Facebook is not the first in this specific order. If `hashtag` is not specified it defaults to (the first hashtag in) `hashtags`

https://developers.facebook.com/docs/sharing/reference/share-dialog#params_share